### PR TITLE
fixed page not found route

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -24,7 +24,7 @@ const AppRoutes: FC = () => {
         <Route path="/csa-tester" element={<CsaTester />} />
         <Route path="/intern/last-opp" element={<PhotoUpload />} />
         <Route path="/intern/arkivsjef" element={<Arkivsjef />} />
-        <Route element={<NotFound />} />
+        <Route path="*" element={<NotFound />} />
       </Routes>
     </>
   );


### PR DESCRIPTION

fix on route to page not found for all pages that dont match any other route

how to check:
- go to a path that is not defined and the page not found should come up
