### PR TITLE
fixed photoApi to have currentList as response type

### DIFF
--- a/src/utils/api/PhotoApi.ts
+++ b/src/utils/api/PhotoApi.ts
@@ -19,7 +19,7 @@ export const PhotoPostDto = new PhotoPost();
 
 export const PhotoApi = {
   getAllByMotiveId: async function (id: string): Promise<PhotoDto[]> {
-    return api.get(`/photos/motive/${id}`).then((res) => res.data);
+    return api.get(`/photos/motive/${id}`).then((res) => res.data.currentList);
   },
   post: async function (photo: Photo): Promise<Photo> {
     return api.post("/photos", photo);


### PR DESCRIPTION


- changed response type in PhotoApi to be res.data.currentList insted of res.data

how to check:
- when running backend route /motive/94540f3c-77b8-4bc5-acc7-4dd7d8cc4bcd will not give an error