### PR TITLE
Fixed label overlapping select input inn "last opp" form

### DIFF
--- a/src/components/Form/Select.tsx
+++ b/src/components/Form/Select.tsx
@@ -32,10 +32,12 @@ const Select: FC<FormFieldProps<SelectProps & WithStyles<typeof styles>>> = ({
   const error = touched && errors[name];
   return (
     <FormControl fullWidth={fullWidth}>
-      <InputLabel htmlFor={name}>{label}</InputLabel>
+      <InputLabel id={`${id}-label-id`} htmlFor={name}>{label}</InputLabel>
       <MuiSelect
         id={id}
+        labelId={`${id}-label-id`}
         name={name}
+        label={label}
         onChange={(e) => onChange(name, e.target.value)}
         value={values[name]}
         onBlur={() => setTouched(true)}


### PR DESCRIPTION
- gave input label an id and MuiSelect an label id and the label.
open /intern/last-opp and labels will not overlap the borderline of the input fields