### PR TITLE
lalala fiksa

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: "daily"
+    open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-patch"
+          

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,3 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-patch"
-          


### PR DESCRIPTION
gjorde sånn at de minste patch updates ikke trigger dependabot, slik vi har på backenden etter nylig